### PR TITLE
[Ticket 3] Make sourcing device-dependent configuration script configurable

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@
 @author: madpang
 @date:
 - created on 2025-01-18
-- updated on 2025-01-19
+- updated on 2025-01-26
 +++
 
 === Introduction
@@ -12,6 +12,25 @@
 It is a collection of scripts and functions that I use in my daily work.
 
 It is inspired by [Oh My Zsh](https://ohmyz.sh).
+
+=== Usage
+
+--- To add device-dependent configurations
+
+To add device-dependent configurations, 
+1. Create your configuration file at `conf` directory, e.g. `device-00-pwsh-conf.ps1`.
+2. Create a `device-info` file in the dedicated ohmypwsh config directory---for macOS, the full path is `~/.ohmypwsh.d/device-info`---to link the configuration file name to the device name.
+
+The content of the `device-info` file may look like this (`+++ JSON` and `+++` are part of the content):
+```
++++ JSON
+{
+	"Your-Device-Name": {
+		ConfPath: "device-00-pwsh-conf.ps1"
+	}
+}
++++
+```
 
 === Advanced usage
 
@@ -39,7 +58,7 @@ Then encrypt the JSON file with GPG, e.g.
 gpg --encrypt --armor --recipient <your_address@email.com> ./workspace-info
 +++
 
-Put the encrypted file in the dedicated ohmypwsh config directory---for macOS, the full path is  `~/.ohmypwsh.d/workspace-info.asc`.
+Put the encrypted file in the dedicated ohmypwsh config directory---for macOS, the full path is `~/.ohmypwsh.d/workspace-info.asc`.
 
 There you go, the `Mount-Workspace` function will automatically load the parameters from the encrypted JSON file, and mount the remote storage for you with `Mount-Workspace WkspID`.
 

--- a/example/device-info
+++ b/example/device-info
@@ -1,0 +1,16 @@
++++ header
+@file: device-info
+@brief: A plain text file that contains non-sensitive information about the device.
+@author: foobar <your_address@email.com>
+@date:
+- created on 2025-01-26
+- updated on 2025-01-26
++++
+
++++ JSON
+{
+	"Your-Machine-Name": {
+		ConfPath: "device-00-pwsh-conf.ps1"
+	}
+}
++++

--- a/tickets.txt
+++ b/tickets.txt
@@ -101,14 +101,14 @@ This method fits well for the scenario of *device-dependent* `Mount-Workspace` f
 @brief:
 Make sourcing device-dependent conf. script configurable.
 
-@status: TODO
+@status: DONE
 
 @date:
 - created on 2025-01-19
-- updated on 2025-01-19
+- updated on 2025-01-26
 
 @details:
-Currently, the device-dependent conf. file name is hard-coded in the main script `pwshrc.ps1`---it is `device-00-pwsh-conf.ps1`.
+See README [Usage] -> [To add device-dependent configurations] for details.
 
 === Ticket 4
 


### PR DESCRIPTION
Allow user to create a `device-info` file to link the device name to the configuration file name.